### PR TITLE
Removed extraneous requires

### DIFF
--- a/src/Authenticator.php
+++ b/src/Authenticator.php
@@ -1,7 +1,6 @@
 <?php
 namespace coviu\Api;
 
-require_once('vendor/autoload.php');
 /*
  Authenticator adds the OAuth2 authentication behaviour to a coviu\Api\Request.
  */

--- a/src/OAuth2Client.php
+++ b/src/OAuth2Client.php
@@ -19,8 +19,6 @@
 
 namespace coviu\Api;
 
-require_once('vendor/autoload.php');
-
 class OAuth2Client
 {
   /** @var string */

--- a/src/OAuth2ClientException.php
+++ b/src/OAuth2ClientException.php
@@ -2,8 +2,6 @@
 
 namespace coviu\Api;
 
-require_once('vendor/autoload.php');
-
 class OAuth2ClientException extends \Exception
 {
   public $response;


### PR DESCRIPTION
`require_once('vendor/autoload.php')` inside library code breaks when using a library for a wordpress plugin (And likely for other use cases).
